### PR TITLE
Fix indentation error in ai_processor

### DIFF
--- a/lambda/ai_processor.py
+++ b/lambda/ai_processor.py
@@ -232,4 +232,4 @@ def is_conversation_reset_needed(messages):
         "新しい話題", "話題を変えて", "リセット", "最初から", "忘れて",
         "new topic", "change subject", "reset", "start over", "forget"
     ]
-        return any(keyword in last_message['content'].lower() for keyword in reset_keywords)
+    return any(keyword in last_message['content'].lower() for keyword in reset_keywords)


### PR DESCRIPTION
## Summary
- correct indentation in `ai_processor.py`

## Testing
- `pytest -q`
- `python -m py_compile lambda/ai_processor.py && echo 'py_compile success'`

------
https://chatgpt.com/codex/tasks/task_e_686e30d112808323bb3c8dad43c2af93