### PR TITLE
fix: add --ci flag to CDK deploy for CI environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,7 +136,7 @@ jobs:
     - name: Deploy to AWS
       run: |
         cd cdk
-        pnpm run cdk deploy -- --require-approval never
+        pnpm run cdk deploy --require-approval never --ci
         
     - name: Notify deployment success
       if: success()


### PR DESCRIPTION
## Summary
- Add `--ci` flag to CDK deploy command to explicitly indicate CI environment
- Should resolve TTY approval prompt issue during AWS deployment
- Force CI detection to ensure logs go to stdout instead of stderr

## Changes
- Update deploy workflow to use `pnpm run cdk deploy --require-approval never --ci`

## Problem Solved
Previous deployment failed with:
```
"--require-approval" is enabled and stack includes security-sensitive updates, but terminal (TTY) is not attached so we are unable to get a confirmation from the user
```

The `--ci` flag explicitly tells CDK this is a CI environment and prevents TTY-related issues.

## Test Plan
- [x] Command syntax verified locally
- [ ] GitHub Actions deployment test

🤖 Generated with [Claude Code](https://claude.ai/code)