### PR TITLE
fix: ensure userId and conversationId are strings in delete_conversat…

### DIFF
--- a/lambda/ai_processor.py
+++ b/lambda/ai_processor.py
@@ -193,8 +193,8 @@ def delete_conversation_history(user_id):
             for item in response['Items']:
                 batch.delete_item(
                     Key={
-                        'userId': item['userId'],
-                        'conversationId': item['conversationId']
+                        'userId': str(item['userId']),
+                        'conversationId': str(item['conversationId'])
                     }
                 )
         


### PR DESCRIPTION
This pull request includes a small but important change to the `delete_conversation_history` function in `lambda/ai_processor.py`. The change ensures that the `userId` and `conversationId` keys are explicitly converted to strings when deleting items from the database.