### PR TITLE
fix: correct DynamoDB key structure for conversation history deletion

### DIFF
--- a/lambda/ai_processor.py
+++ b/lambda/ai_processor.py
@@ -217,13 +217,12 @@ def delete_conversation_history(user_id):
             KeyConditionExpression=Key('userId').eq(user_id)
         )
         
-        # Delete each item
+        # Delete each item using only the partition key (userId)
         with conversation_table.batch_writer() as batch:
             for item in response['Items']:
                 batch.delete_item(
                     Key={
-                        'userId': str(item['userId']),
-                        'conversationId': str(item['conversationId'])
+                        'userId': str(item['userId'])
                     }
                 )
         


### PR DESCRIPTION
## Summary
- Fix `/忘れて` command that was failing due to incorrect DynamoDB key structure
- Remove non-existent `conversationId` from delete operation key
- Align with actual table schema that only has `userId` as partition key

## Problem
CloudWatch logs showed ValidationException when using conversation history deletion:
```
Error deleting conversation history for user Ue012ea4cc83965acd3448d28ef47bfeb: 
An error occurred (ValidationException) when calling the BatchWriteItem operation: 
The provided key element does not match the schema
```

## Root Cause
- DynamoDB table `line-bot-conversations` only has `userId` as partition key (no sort key)
- Delete function was attempting to use both `userId` and `conversationId` as keys
- `conversationId` field exists in data but is not part of the key schema

## Solution
Updated `delete_conversation_history()` function to use only the partition key:
```python
# Before (incorrect)
Key={
    'userId': str(item['userId']),
    'conversationId': str(item['conversationId'])  # Non-existent key
}

# After (correct)
Key={
    'userId': str(item['userId'])  # Only partition key
}
```

## Test Plan
- [x] Verify DynamoDB table schema structure
- [x] Identify ValidationException in CloudWatch logs
- [x] Test `/忘れて` command functionality
- [x] Confirm batch delete operation works with correct key structure

## Impact
✅ `/忘れて` command now works properly to delete conversation history
✅ No more ValidationException errors in CloudWatch logs
✅ Improved user experience with working reset functionality

🤖 Generated with [Claude Code](https://claude.ai/code)