### PR TITLE
fix(scripts): preserve opentelemetry dist-info in Lambda Layer

### DIFF
--- a/scripts/build-layer.sh
+++ b/scripts/build-layer.sh
@@ -36,9 +36,12 @@ uv export --no-dev --no-hashes | uv pip install --target "$LAYER_PYTHON_DIR" -r 
 # Remove unnecessary files to reduce layer size
 echo "🗑️ Removing unnecessary files..."
 find "$LAYER_PYTHON_DIR" -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
-find "$LAYER_PYTHON_DIR" -type d -name "*.dist-info" -exec rm -rf {} + 2>/dev/null || true
 find "$LAYER_PYTHON_DIR" -type f -name "*.pyc" -delete 2>/dev/null || true
 find "$LAYER_PYTHON_DIR" -type f -name "*.pyo" -delete 2>/dev/null || true
+
+# Remove dist-info directories EXCEPT opentelemetry (needed for entry_points discovery)
+echo "🗑️ Removing dist-info (preserving opentelemetry)..."
+find "$LAYER_PYTHON_DIR" -type d -name "*.dist-info" ! -name "opentelemetry*.dist-info" -exec rm -rf {} + 2>/dev/null || true
 
 # Show layer size
 LAYER_SIZE=$(du -sh "$LAYER_OUTPUT_DIR" | cut -f1)


### PR DESCRIPTION
## Summary
- xAI呼び出し時にGrokProcessorがクラッシュする問題を修正
- `xai_sdk`が依存する`opentelemetry`がentry_points.txtを必要としていた
- Lambda Layerビルド時に`.dist-info`を全削除していたのが原因
- opentelemetry関連のdist-infoのみ保持するように変更

## Root Cause
```
StopIteration
File "/opt/python/opentelemetry/context/__init__.py", line 60, in _load_runtime_context
    return next(  # type: ignore
```
`opentelemetry`はインポート時に`importlib.metadata`で`entry_points.txt`からコンテキストプロバイダーを検索する。このファイルが存在しないと`StopIteration`で失敗する。

## Test plan
- [ ] GitHub ActionsでCDKデプロイが成功
- [ ] LINEからxAI検索リクエストを送信して応答が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)