### PR TITLE
fix(lambda): migrate from deprecated Live Search to Agent Tools API

### DIFF
--- a/lambda/grok_processor.py
+++ b/lambda/grok_processor.py
@@ -6,7 +6,7 @@ from typing import Any
 import boto3
 from xai_sdk import Client
 from xai_sdk.chat import user
-from xai_sdk.search import SearchParameters
+from xai_sdk.tools import web_search
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -80,10 +80,10 @@ def call_grok_api(query: str, prompt: str | None) -> str:
         # Initialize xAI client
         client = Client(api_key=get_xai_api_key())
 
-        # Create chat with search parameters
+        # Create chat with web search tool (Agent Tools API)
         chat = client.chat.create(
-            model="grok-4",
-            search_parameters=SearchParameters(mode="on"),
+            model="grok-4-1-fast",
+            tools=[web_search()],
         )
 
         # Create search prompt in Japanese


### PR DESCRIPTION
## Summary
- xAIのLive Search APIが廃止されたため、Agent Tools APIに移行
- `SearchParameters(mode="on")` → `tools=[web_search()]`
- モデルを `grok-4-1-fast` に変更（agentic requests推奨）

## Error before fix
```
status = StatusCode.UNIMPLEMENTED
details = "Live search is deprecated. Please switch to the Agent Tools API"
```

## Test plan
- [ ] LINEからxAI検索リクエストを送信して応答が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)