### PR TITLE
chore(grok): migrate to grok-4.3 ahead of 2026-05-15 retirement

### DIFF
--- a/docs/xai/grok_integration.md
+++ b/docs/xai/grok_integration.md
@@ -1,7 +1,7 @@
 
-# xAI Grok-4 and Live Search API Integration
+# xAI Grok and Live Search API Integration
 
-xAIのGrok-4モデルとLive Search APIを統合することで、リアルタイムのWeb情報を活用して応答を生成する検索エージェントを実装できます。
+xAIのGrokモデルとLive Search APIを統合することで、リアルタイムのWeb情報を活用して応答を生成する検索エージェントを実装できます。
 
 ## Live Search API
 
@@ -13,13 +13,13 @@ Live Search機能を利用するには、APIリクエストに`search_parameters
 
 ### Pythonでの使用例 (langchain_xai)
 
-`langchain_xai`ライブラリを使用すると、Grok-4モデルとLive Search機能を簡単に利用できます。
+`langchain_xai`ライブラリを使用すると、GrokモデルとLive Search機能を簡単に利用できます。
 
 ```python
 from langchain_xai import ChatXAI
 
 llm = ChatXAI(
-    model="grok-4",
+    model="grok-4.3",
     search_parameters={
         "mode": "auto",
         # オプションのパラメータ例
@@ -30,9 +30,9 @@ llm = ChatXAI(
 )
 ```
 
-## Grok-4モデル
+## Grokモデル
 
-Grok-4は、xAIの最新の推論モデルであり、画像とテキストの両方の入力をサポートしています。
+`grok-4.3` は xAI の最新の汎用モデルで、エージェント的なツール呼び出しと指示追従に優れています。`<modelname>` エイリアスで最新の安定版を自動的に追従するため、本プロジェクトでも `grok-4.3` を使用します（旧モデル `grok-4-1-fast` 系は 2026-05-15 に廃止）。
 
 ## APIアクセスと料金
 

--- a/lambda/grok_processor.py
+++ b/lambda/grok_processor.py
@@ -74,7 +74,7 @@ def call_grok_api(query: str, prompt: str | None) -> str:
         Response content from Grok API
     """
     try:
-        logger.info(f"Calling Grok-4 with query: {query}")
+        logger.info(f"Calling Grok with query: {query}")
         logger.info(f"Using prompt: {prompt if prompt else 'No prompt provided'}")
 
         # Initialize xAI client
@@ -82,7 +82,7 @@ def call_grok_api(query: str, prompt: str | None) -> str:
 
         # Create chat with web search tool (Agent Tools API)
         chat = client.chat.create(
-            model="grok-4-1-fast",
+            model="grok-4.3",
             tools=[web_search()],
         )
 
@@ -98,7 +98,7 @@ def call_grok_api(query: str, prompt: str | None) -> str:
         return str(response.content)
 
     except Exception as e:
-        logger.error(f"Error calling Grok-4 API: {e}")
+        logger.error(f"Error calling Grok API: {e}")
         return "ごめんやで～、こびとさんが情報見つけられへんかった...。もうちょっと簡単な言葉で聞いてみてくれる？"
 
 
@@ -112,7 +112,7 @@ def lambda_handler(event: dict, _context) -> dict:
 
     try:
         grok_response = call_grok_api(query, prompt)
-        logger.info(f"Grok-4 response received: {grok_response}")
+        logger.info(f"Grok response received: {grok_response}")
 
         # Return the response with all necessary context for the next lambda
         response_data = {


### PR DESCRIPTION
## Summary

xAI が 2026-05-15 に以下のモデルを廃止するため、`grok-4.3` へ移行する。

廃止対象 (xAI公式アナウンス):
- \`grok-4-1-fast-reasoning\` / \`grok-4-1-fast-non-reasoning\` ← **当プロジェクトで使用中**
- \`grok-4-fast-*\`, \`grok-4-0709\`, \`grok-code-fast-1\`, \`grok-3\`, \`grok-imagine-image-pro\`

xAI公式の推奨移行先:
- 推論ワークロード → \`grok-4.3\`
- 非推論 → \`grok-4.20-non-reasoning\`
- 画像生成 → \`grok-imagine-image\`

## 変更内容

| ファイル | 変更 |
|---------|------|
| \`lambda/grok_processor.py:85\` | \`grok-4-1-fast\` → \`grok-4.3\` |
| \`lambda/grok_processor.py\` (logs) | \`Grok-4\` → \`Grok\` (バージョン非依存に) |
| \`docs/xai/grok_integration.md\` | サンプルコードと説明文を \`grok-4.3\` に統一 |

このプロジェクトの用途は **エージェント的Web検索** で、xAI 4.3 リリース告知でも "tops leaderboards in agentic tool calling" と明記されているため、推奨先として最適。

## Test plan

- [x] \`grok_processor.py\` の構文チェック (import成功)
- [ ] CI \`test\` ジョブ通過
- [ ] マージ後の deploy 成功
- [ ] Grok 検索が引き続き動作することを実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)