### PR TITLE
chore(grok): log web_search citations and align docs with xai_sdk

### DIFF
--- a/docs/xai/grok_integration.md
+++ b/docs/xai/grok_integration.md
@@ -1,41 +1,77 @@
+# xAI Grok and Tools API Integration
 
-# xAI Grok and Live Search API Integration
+xAI の Grok モデルと Tools API（旧称 Live Search を含む組み込みツール群）を統合することで、リアルタイムの Web 情報を活用して応答を生成する検索エージェントを実装できます。本プロジェクトでは公式 Python SDK の `xai_sdk` を直接利用しており、`lambda/grok_processor.py` で `web_search` ツールを有効化した chat セッションを生成しています。
 
-xAIのGrokモデルとLive Search APIを統合することで、リアルタイムのWeb情報を活用して応答を生成する検索エージェントを実装できます。
+## Tools API の概要
 
-## Live Search API
+xAI の組み込みツールはサーバーサイドで自動実行される。`tools` 引数にツール関数を渡すと、モデルが必要に応じて自律的に呼び出す。
 
-Live Search機能を利用するには、APIリクエストに`search_parameters`オブジェクトを含めます。このオブジェクトの`mode`フィールドで検索の動作を制御します。
+| ツール | 用途 | gRPC SDK 対応 |
+|--------|------|----------------|
+| `web_search()` | Web 検索 | ✅ |
+| `x_search()` | X (Twitter) 検索 | ✅ |
+| `code_execution()` | サンドボックス Python 実行 | ❌ (Responses API のみ) |
+| `collections_search()` | xAI にアップロードしたドキュメント (RAG) | ❌ |
+| `attachment_search()` | メッセージ添付ファイル検索 | ✅ |
 
-*   **`off`**: 検索機能を無効にします。
-*   **`auto`**: (デフォルト) モデルが検索を実行するかどうかを決定します。
-*   **`on`**: モデルに常にライブ検索を強制します。
+> Note: Python xAI SDK (gRPC) では `code_interpreter` と `file_search` は使えない。これらが必要な場合は OpenAI 互換の Responses API (`POST /v1/responses`) を利用する。
 
-### Pythonでの使用例 (langchain_xai)
+## 実装例 (xai_sdk)
 
-`langchain_xai`ライブラリを使用すると、GrokモデルとLive Search機能を簡単に利用できます。
+`lambda/grok_processor.py` で実際に使っているパターン。
 
 ```python
-from langchain_xai import ChatXAI
+import os
+from xai_sdk import Client
+from xai_sdk.chat import user
+from xai_sdk.tools import web_search
 
-llm = ChatXAI(
+client = Client(api_key=os.getenv("XAI_API_KEY"))
+chat = client.chat.create(
     model="grok-4.3",
-    search_parameters={
-        "mode": "auto",
-        # オプションのパラメータ例
-        "max_search_results": 3,
-        "from_date": "2025-05-26",
-        "to_date": "2025-05-27",
-    }
+    tools=[web_search()],
 )
+chat.append(user("最近のxAIのアップデート教えて"))
+
+response = chat.sample()
+
+# 本文
+print(response.content)
+
+# 検索ソース URL（list[str]）
+print(response.citations)
 ```
 
-## Grokモデル
+`response.citations` には `web_search` が参照したソース URL の一覧が入る。本プロジェクトでは観測用に CloudWatch Logs に記録している（ユーザーへの返信本文には含めない）。
 
-`grok-4.3` は xAI の最新の汎用モデルで、エージェント的なツール呼び出しと指示追従に優れています。`<modelname>` エイリアスで最新の安定版を自動的に追従するため、本プロジェクトでも `grok-4.3` を使用します（旧モデル `grok-4-1-fast` 系は 2026-05-15 に廃止）。
+### ストリーミング
 
-## APIアクセスと料金
+逐次出力したい場合は `chat.stream()` を使う。LINE bot は完成したテキストを Push API で送るため非ストリーム (`chat.sample()`) を採用。
 
-Grok APIを利用するには、xAIアカウントの作成、請求設定、APIキーの生成が必要です。
+```python
+for response, chunk in chat.stream():
+    if chunk.content:
+        print(chunk.content, end="", flush=True)
+```
 
-Live Search機能の料金は、使用されたソースの数に基づいており、1,000ソースあたり25ドルです。使用されたソースの数は、応答オブジェクトの`response.usage.num_sources_used`フィールドで確認できます。
+## Grok モデル
+
+`grok-4.3` は xAI の最新の汎用モデルで、エージェント的なツール呼び出しと指示追従に優れる。`<modelname>` エイリアスは最新の安定版に自動追従するため、本プロジェクトでも `grok-4.3` を使用（旧モデル `grok-4-1-fast` 系は 2026-05-15 に廃止）。
+
+## 料金 (2026-05 時点)
+
+Tools API のコストは「トークン使用量」と「ツール呼び出し数」の合算。
+
+| トークン (grok-4.3) | 単価 |
+|---------------------|------|
+| 入力 | $1.25 / 1M tokens |
+| 出力 | $2.50 / 1M tokens |
+
+| ツール呼び出し | 単価 |
+|----------------|------|
+| `web_search` / `x_search` | $5 / 1k calls |
+| `code_execution` | $5 / 1k calls |
+| `collections_search` | $2.50 / 1k calls |
+| `attachment_search` | $10 / 1k calls |
+
+旧 Live Search の「使用ソース数 × $25 / 1k」モデルからは値下げ。

--- a/lambda/grok_processor.py
+++ b/lambda/grok_processor.py
@@ -95,6 +95,15 @@ def call_grok_api(query: str, prompt: str | None) -> str:
 
         # Get response
         response = chat.sample()
+
+        # Log web_search citations for observability; do not surface to the user.
+        try:
+            citations = list(response.citations) if response.citations else []
+            if citations:
+                logger.info("Grok web_search citations: %s", citations)
+        except (AttributeError, TypeError):
+            pass
+
         return str(response.content)
 
     except Exception as e:


### PR DESCRIPTION
## Summary

Grok-4.3 移行のフォローアップ。**ボットの応答テキストは不変** の範囲で API の最新仕様に追従する。

### A. \`response.citations\` の取得 (ログのみ)

xAI Tools API は \`web_search\` で参照したソース URL を \`response.citations\` で返す。これまで捨てられていたデータを CloudWatch Logs に記録し、検索品質の調査・改善ができる足場にする。

- 既存ロジック (\`response_sender\`、\`grokResponse\` のフィールド名、Step Functions) は変更なし
- LINE 返信本文と会話履歴も変更なし
- SDK の戻り値 shape 変動に備えて \`try/except\` で防御

### B. ドキュメントを \`xai_sdk\` ベースに整理

\`docs/xai/grok_integration.md\` のサンプルが \`langchain_xai\` だったが、実コードは \`xai_sdk\` 直接利用なので不整合だった。実装と一致させた上で:

- gRPC SDK で使えるツール表を追加 (\`code_interpreter\` / \`collections_search\` などは Responses API のみと明記)
- 料金を最新の Tools-API モデル (\`web_search\` $5/1k 等) に更新
- ストリーミング (\`chat.stream\`) と非ストリーム (\`chat.sample\`) の使い分けを記載

## Test plan

- [x] \`grok_processor.py\` の構文/import チェック
- [ ] CI \`test\` ジョブ通過
- [ ] マージ後の deploy 成功
- [ ] 検索クエリ実行後に CloudWatch Logs で \`Grok web_search citations:\` が出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)