### PR TITLE
feat(lambda): refine bot responses with markdown stripping and citations

### DIFF
--- a/cdk/test/__snapshots__/line-echo-stack.snapshot.test.ts.snap
+++ b/cdk/test/__snapshots__/line-echo-stack.snapshot.test.ts.snap
@@ -342,7 +342,7 @@ exports[`LINE Echo Stack - Snapshot Tests CloudFormation Template Snapshots shou
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0ce1929e0930959a6c37d4fdc5828ef45fb3f71fffe1c7d391df926f2d424c5e.zip",
+          "S3Key": "0d039f34fc0acdbbd009ee0fb385aa04f60e61bb84af00fcd520370be748557f.zip",
         },
         "Description": "Processes user messages using SambaNova AI",
         "Environment": {
@@ -540,7 +540,7 @@ exports[`LINE Echo Stack - Snapshot Tests CloudFormation Template Snapshots shou
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "f385f7a3a39b764db843c44242e032762e0b28154f911995a63756a3a5e74fe1.zip",
+          "S3Key": "21b38d2dd4ea2746430c9da41a5005aca728ca15dccb7bc3b7e4546cf8485bf2.zip",
         },
         "Description": "Python dependencies for LINE bot Lambda functions",
       },
@@ -901,7 +901,7 @@ exports[`LINE Echo Stack - Snapshot Tests CloudFormation Template Snapshots shou
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0ce1929e0930959a6c37d4fdc5828ef45fb3f71fffe1c7d391df926f2d424c5e.zip",
+          "S3Key": "0d039f34fc0acdbbd009ee0fb385aa04f60e61bb84af00fcd520370be748557f.zip",
         },
         "Description": "Processes queries using Grok AI for web search",
         "Environment": {
@@ -1010,7 +1010,7 @@ exports[`LINE Echo Stack - Snapshot Tests CloudFormation Template Snapshots shou
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0ce1929e0930959a6c37d4fdc5828ef45fb3f71fffe1c7d391df926f2d424c5e.zip",
+          "S3Key": "0d039f34fc0acdbbd009ee0fb385aa04f60e61bb84af00fcd520370be748557f.zip",
         },
         "Description": "Sends interim response while processing complex queries",
         "Environment": {
@@ -1119,7 +1119,7 @@ exports[`LINE Echo Stack - Snapshot Tests CloudFormation Template Snapshots shou
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0ce1929e0930959a6c37d4fdc5828ef45fb3f71fffe1c7d391df926f2d424c5e.zip",
+          "S3Key": "0d039f34fc0acdbbd009ee0fb385aa04f60e61bb84af00fcd520370be748557f.zip",
         },
         "Description": "Sends final response to LINE and saves conversation history",
         "Environment": {
@@ -1259,7 +1259,7 @@ exports[`LINE Echo Stack - Snapshot Tests CloudFormation Template Snapshots shou
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0ce1929e0930959a6c37d4fdc5828ef45fb3f71fffe1c7d391df926f2d424c5e.zip",
+          "S3Key": "0d039f34fc0acdbbd009ee0fb385aa04f60e61bb84af00fcd520370be748557f.zip",
         },
         "Description": "Handles LINE webhook events and initiates AI processing",
         "Environment": {

--- a/lambda/ai_processor.py
+++ b/lambda/ai_processor.py
@@ -8,6 +8,7 @@ import boto3
 import openai
 import pytz
 from boto3.dynamodb.conditions import Key
+from markdown_to_line import render_to_line
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -203,9 +204,10 @@ def get_ai_response(messages: list) -> dict:
                     "toolPrompt": prompt,
                 }
 
-        ai_response = message.content
+        ai_response = message.content or ""
         logger.info(f"{backend_name} API response received: {ai_response}")
-        return {"hasToolCall": False, "aiResponse": ai_response}
+        plain, _ = render_to_line(ai_response)
+        return {"hasToolCall": False, "aiResponse": plain}
 
     except Exception as e:
         logger.error(f"Error calling SambaNova API: {e}")

--- a/lambda/grok_processor.py
+++ b/lambda/grok_processor.py
@@ -4,6 +4,7 @@ import os
 from typing import Any
 
 import boto3
+from markdown_to_line import format_with_citations, merge_citations, render_to_line
 from xai_sdk import Client
 from xai_sdk.chat import user
 from xai_sdk.tools import web_search
@@ -64,14 +65,17 @@ def get_xai_api_key() -> str:
     return XAI_API_KEY
 
 
-def call_grok_api(query: str, prompt: str | None) -> str:
+def call_grok_api(query: str, prompt: str | None) -> tuple[str, str]:
     """Call xAI Grok API for search using official SDK.
 
     Args:
         query: Search query string
 
     Returns:
-        Response content from Grok API
+        Tuple of `(final_response, body_only)`. `final_response` is what is sent
+        to the user (body + citation footer). `body_only` is the same body
+        without the footer, to be saved into conversation history so that
+        future turns are not polluted by URL footers.
     """
     try:
         logger.info(f"Calling Grok with query: {query}")
@@ -96,19 +100,22 @@ def call_grok_api(query: str, prompt: str | None) -> str:
         # Get response
         response = chat.sample()
 
-        # Log web_search citations for observability; do not surface to the user.
         try:
-            citations = list(response.citations) if response.citations else []
-            if citations:
-                logger.info("Grok web_search citations: %s", citations)
+            api_citations = list(response.citations) if response.citations else []
         except (AttributeError, TypeError):
-            pass
+            api_citations = []
+        if api_citations:
+            logger.info("Grok web_search citations: %s", api_citations)
 
-        return str(response.content)
+        plain_body, body_urls = render_to_line(str(response.content or ""))
+        merged = merge_citations(api_citations, body_urls)
+        final = format_with_citations(plain_body, merged)
+        return final, plain_body
 
     except Exception as e:
         logger.error(f"Error calling Grok API: {e}")
-        return "ごめんやで～、こびとさんが情報見つけられへんかった...。もうちょっと簡単な言葉で聞いてみてくれる？"
+        fallback = "ごめんやで～、こびとさんが情報見つけられへんかった...。もうちょっと簡単な言葉で聞いてみてくれる？"
+        return fallback, fallback
 
 
 def lambda_handler(event: dict, _context) -> dict:
@@ -120,12 +127,15 @@ def lambda_handler(event: dict, _context) -> dict:
     prompt = event.get("toolPrompt", "")
 
     try:
-        grok_response = call_grok_api(query, prompt)
+        grok_response, grok_body = call_grok_api(query, prompt)
         logger.info(f"Grok response received: {grok_response}")
 
-        # Return the response with all necessary context for the next lambda
+        # `grokResponse` is sent to the user (body + citation footer).
+        # `grokBody` is saved into history without the footer so future LLM
+        # turns are not polluted by URL lists.
         response_data = {
             "grokResponse": grok_response,
+            "grokBody": grok_body,
             "userId": event.get("userId"),
             "conversationContext": event.get("conversationContext"),
             "sourceType": event.get("sourceType"),
@@ -140,9 +150,10 @@ def lambda_handler(event: dict, _context) -> dict:
 
     except Exception as e:
         logger.error(f"Error in Grok processor: {e}")
-        # Return a user-friendly error message with context
+        fallback = "ごめんやで〜、こびとさんが情報見つけられへんかったわ...。もうちょっと簡単な言葉で聞いてみてくれる？"
         error_response = {
-            "grokResponse": "ごめんやで〜、こびとさんが情報見つけられへんかったわ...。もうちょっと簡単な言葉で聞いてみてくれる？",
+            "grokResponse": fallback,
+            "grokBody": fallback,
             "userId": event.get("userId"),
             "conversationContext": event.get("conversationContext"),
             "sourceType": event.get("sourceType"),

--- a/lambda/interim_response_sender.py
+++ b/lambda/interim_response_sender.py
@@ -8,6 +8,7 @@ from linebot.v3.messaging import (
     Configuration,
     MessagingApi,
     PushMessageRequest,
+    ShowLoadingAnimationRequest,
     TextMessage,
 )
 
@@ -62,6 +63,11 @@ def lambda_handler(event: dict, _context) -> dict:
             "なんやややこしい質問やな～ 今こびとさんに調べてきてもろとるから待っとき！"
         )
 
+        # Show loading dots first (1-on-1 only) so the order in chat is:
+        # typing indicator → interim text → final answer.
+        if source_type not in ("group", "room"):
+            show_loading(user_id)
+
         # Get quote token if available for group/room messages
         quote_token: str | None = event.get("quote_token")
         send_line_message(target_id, interim_message, quote_token, source_type)
@@ -73,6 +79,24 @@ def lambda_handler(event: dict, _context) -> dict:
         logger.error(f"Error in interim response sender: {e}")
         # Propagate the error to stop the workflow
         raise
+
+
+def show_loading(user_id: str, seconds: int = 60) -> None:
+    """Show LINE typing-style loading animation for a 1-on-1 chat.
+
+    Best-effort: any failure is logged and swallowed so the workflow proceeds.
+    """
+    try:
+        with ApiClient(configuration) as api_client:
+            line_bot_api = MessagingApi(api_client)
+            line_bot_api.show_loading_animation(
+                show_loading_animation_request=ShowLoadingAnimationRequest(
+                    chatId=user_id, loadingSeconds=seconds
+                )
+            )
+        logger.info("Showed loading animation for %s (%ds)", user_id, seconds)
+    except Exception as e:
+        logger.warning("Failed to show loading animation: %s", e)
 
 
 def send_line_message(

--- a/lambda/markdown_to_line.py
+++ b/lambda/markdown_to_line.py
@@ -1,0 +1,185 @@
+"""Convert markdown text to LINE-friendly plain text.
+
+LINE のテキストメッセージは markdown 装飾を表示できないため、
+共通処理として AST ベースで装飾を除去し、リンクの URL を抽出する。
+
+`render_to_line(text)` が中心の関数。装飾の除去ルールは LINE/日本語環境を想定:
+
+- heading       → `■ {text}` （階層はフラット化）
+- strong/em/del → 装飾のみ除去、本文はそのまま
+- code inline   → `〈{text}〉`
+- code block    → 改行を保ったままそのまま
+- bullet list   → 行頭 `・`、ネストはインデント2スペース
+- ordered list  → `{N}. `
+- link          → 本文に表示テキストのみ残し、URL は呼び出し側に返す
+- blockquote    → 各行を `｜ ` で前置
+- hr            → `────`
+"""
+
+from __future__ import annotations
+
+import re
+
+from markdown_it import MarkdownIt
+from markdown_it.token import Token
+
+
+def render_to_line(text: str) -> tuple[str, list[str]]:
+    """Render markdown text to LINE plain text.
+
+    Args:
+        text: Source markdown text.
+
+    Returns:
+        Tuple of `(plain_text, urls)` where `plain_text` has all semantic
+        decorations stripped and markdown link URLs removed, and `urls` is the
+        list of href values from markdown links in document order, deduplicated.
+    """
+    if not text:
+        return "", []
+
+    md = MarkdownIt("commonmark")
+    tokens = md.parse(text)
+    rendered, urls = _render_tokens(tokens)
+
+    rendered = re.sub(r"\n{3,}", "\n\n", rendered).strip()
+
+    seen: dict[str, None] = {}
+    for u in urls:
+        if u:
+            seen.setdefault(u, None)
+    return rendered, list(seen)
+
+
+def merge_citations(*sources: list[str]) -> list[str]:
+    """Merge citation URL lists preserving input order, deduplicated."""
+    seen: dict[str, None] = {}
+    for source in sources:
+        for url in source:
+            if url:
+                seen.setdefault(url, None)
+    return list(seen)
+
+
+def format_with_citations(body: str, citations: list[str], max_citations: int = 5) -> str:
+    """Append a numbered citation footer to body. No-op if citations empty."""
+    if not citations:
+        return body
+    capped = citations[:max_citations]
+    lines = ["🔗 参考"]
+    for i, url in enumerate(capped, 1):
+        lines.append(f"({i}) {url}")
+    return body + "\n\n" + "\n".join(lines)
+
+
+def _render_tokens(tokens: list[Token]) -> tuple[str, list[str]]:
+    # buffer_stack[-1] is the active output buffer; blockquote pushes a new one
+    # so its accumulated content can be prefixed at close time.
+    buffer_stack: list[list[str]] = [[]]
+    urls: list[str] = []
+    list_stack: list[dict] = []
+
+    def emit(s: str) -> None:
+        buffer_stack[-1].append(s)
+
+    for tok in tokens:
+        t = tok.type
+        if t == "heading_open":
+            emit("\n■ ")
+        elif t == "heading_close":
+            emit("\n\n")
+        elif t == "paragraph_open":
+            pass
+        elif t == "paragraph_close":
+            emit("\n" if list_stack else "\n\n")
+        elif t == "bullet_list_open":
+            list_stack.append({"type": "ul", "counter": 0})
+            emit("\n")
+        elif t == "ordered_list_open":
+            list_stack.append({"type": "ol", "counter": 1})
+            emit("\n")
+        elif t in ("bullet_list_close", "ordered_list_close"):
+            if list_stack:
+                list_stack.pop()
+            emit("\n")
+        elif t == "list_item_open":
+            indent = "  " * max(0, len(list_stack) - 1)
+            if list_stack and list_stack[-1]["type"] == "ol":
+                n = list_stack[-1]["counter"]
+                emit(f"{indent}{n}. ")
+                list_stack[-1]["counter"] = n + 1
+            else:
+                emit(f"{indent}・")
+        elif t == "list_item_close":
+            pass
+        elif t == "blockquote_open":
+            buffer_stack.append([])
+        elif t == "blockquote_close":
+            inner = "".join(buffer_stack.pop()).strip("\n")
+            quoted = "\n".join(f"｜ {line}" if line else "｜" for line in inner.split("\n"))
+            emit("\n" + quoted + "\n\n")
+        elif t == "hr":
+            emit("\n────\n")
+        elif t in ("code_block", "fence"):
+            emit("\n" + tok.content.rstrip("\n") + "\n\n")
+        elif t == "inline":
+            inline_text, inline_urls = _render_inline(tok.children or [])
+            emit(inline_text)
+            urls.extend(inline_urls)
+
+    return "".join(buffer_stack[0]), urls
+
+
+def _render_inline(children: list[Token]) -> tuple[str, list[str]]:
+    out: list[str] = []
+    urls: list[str] = []
+    href_stack: list[str] = []
+
+    for c in children:
+        t = c.type
+        if t == "text":
+            out.append(_strip_residual_emphasis(c.content))
+        elif t in ("softbreak", "hardbreak"):
+            out.append("\n")
+        elif t == "code_inline":
+            out.append(f"〈{c.content}〉")
+        elif t in (
+            "strong_open",
+            "strong_close",
+            "em_open",
+            "em_close",
+            "s_open",
+            "s_close",
+        ):
+            pass
+        elif t == "link_open":
+            href = c.attrGet("href") or ""
+            href_stack.append(str(href))
+        elif t == "link_close":
+            if href_stack:
+                href = href_stack.pop()
+                if href and href.startswith(("http://", "https://")):
+                    urls.append(href)
+        elif t == "image":
+            alt = c.content or ""
+            if alt:
+                out.append(alt)
+
+    return "".join(out), urls
+
+
+# CommonMark left/right-flanking rules treat 」』】 etc. as punctuation, which
+# can prevent ** from closing when the next character is a CJK letter (no space).
+# Example: `**「テスト」**です` leaves literal `**...**` after AST. We sweep these
+# orphans only at the inline level so code blocks (rendered from tok.content)
+# stay intact.
+_RE_RESIDUAL_STRONG = re.compile(r"\*\*([^*\n]+?)\*\*")
+_RE_RESIDUAL_EM = re.compile(r"(?<!\*)\*([^*\n]+?)\*(?!\*)")
+_RE_RESIDUAL_DEL = re.compile(r"~~([^\n]+?)~~")
+
+
+def _strip_residual_emphasis(text: str) -> str:
+    text = _RE_RESIDUAL_STRONG.sub(r"\1", text)
+    text = _RE_RESIDUAL_EM.sub(r"\1", text)
+    text = _RE_RESIDUAL_DEL.sub(r"\1", text)
+    return text

--- a/lambda/response_sender.py
+++ b/lambda/response_sender.py
@@ -73,13 +73,16 @@ def lambda_handler(event: dict, _context) -> dict:
         quote_token: str | None = event.get("quote_token")
         send_line_message(target_id, message_to_send, quote_token, source_type)
 
-        # If it was a final response (from Grok), save it to the conversation history
+        # If it was a final response (from Grok), save it to the conversation history.
+        # Save the body without the citation footer so future LLM turns are not
+        # polluted by URL lists.
         if "grokResponse" in event:
             conversation_context = event["conversationContext"]
+            history_content = event.get("grokBody") or message_to_send
             conversation_context["messages"].append(
                 {
                     "role": "assistant",
-                    "content": message_to_send,
+                    "content": history_content,
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                 }
             )

--- a/lambda/tests/test_markdown_to_line.py
+++ b/lambda/tests/test_markdown_to_line.py
@@ -1,0 +1,192 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from markdown_to_line import (  # noqa: E402
+    format_with_citations,
+    merge_citations,
+    render_to_line,
+)
+
+
+class TestRenderToLine(unittest.TestCase):
+    def test_empty(self) -> None:
+        self.assertEqual(render_to_line(""), ("", []))
+
+    def test_plain_paragraph_unchanged(self) -> None:
+        text, urls = render_to_line("こんにちは。元気ですか？")
+        self.assertEqual(text, "こんにちは。元気ですか？")
+        self.assertEqual(urls, [])
+
+    def test_strong_stripped(self) -> None:
+        text, _ = render_to_line("これは **重要** な点です。")
+        self.assertEqual(text, "これは 重要 な点です。")
+
+    def test_em_stripped(self) -> None:
+        text, _ = render_to_line("これは *斜体* の例。")
+        self.assertEqual(text, "これは 斜体 の例。")
+
+    def test_strikethrough_passthrough(self) -> None:
+        # commonmark preset does not parse ~~ as strikethrough; treat as text.
+        text, _ = render_to_line("~~消去~~ もそのまま")
+        self.assertIn("消去", text)
+
+    def test_inline_code_wrapped(self) -> None:
+        text, _ = render_to_line("ファイル名は `config.json` です。")
+        self.assertEqual(text, "ファイル名は 〈config.json〉 です。")
+
+    def test_heading_levels_flattened(self) -> None:
+        text, _ = render_to_line("# 章タイトル\n## 節\n### 小見出し\n本文")
+        self.assertIn("■ 章タイトル", text)
+        self.assertIn("■ 節", text)
+        self.assertIn("■ 小見出し", text)
+
+    def test_bullet_list(self) -> None:
+        text, _ = render_to_line("- 一つ目\n- 二つ目\n- 三つ目")
+        lines = [line for line in text.split("\n") if line]
+        self.assertEqual(lines, ["・一つ目", "・二つ目", "・三つ目"])
+
+    def test_nested_bullet_list_indented(self) -> None:
+        md = "- 親\n  - 子1\n  - 子2\n- 別の親"
+        text, _ = render_to_line(md)
+        self.assertIn("・親", text)
+        self.assertIn("  ・子1", text)
+        self.assertIn("  ・子2", text)
+        self.assertIn("・別の親", text)
+
+    def test_ordered_list_numbered(self) -> None:
+        text, _ = render_to_line("1. 最初\n2. 次\n3. 最後")
+        self.assertIn("1. 最初", text)
+        self.assertIn("2. 次", text)
+        self.assertIn("3. 最後", text)
+
+    def test_link_extracts_url_keeps_text(self) -> None:
+        text, urls = render_to_line("詳細は [公式サイト](https://example.com) を参照。")
+        self.assertEqual(text, "詳細は 公式サイト を参照。")
+        self.assertEqual(urls, ["https://example.com"])
+
+    def test_multiple_links_dedup_and_order(self) -> None:
+        md = "[A](https://a.example) と [B](https://b.example) と [A again](https://a.example)"
+        text, urls = render_to_line(md)
+        self.assertNotIn("https://a.example", text)
+        self.assertNotIn("https://b.example", text)
+        self.assertEqual(urls, ["https://a.example", "https://b.example"])
+
+    def test_non_http_link_skipped(self) -> None:
+        _, urls = render_to_line("[mailto](mailto:foo@example.com)")
+        self.assertEqual(urls, [])
+
+    def test_code_block_preserved(self) -> None:
+        md = "```\nprint('hi')\n```"
+        text, _ = render_to_line(md)
+        self.assertIn("print('hi')", text)
+
+    def test_blockquote_prefixed(self) -> None:
+        text, _ = render_to_line("> 引用された一行\n> 二行目")
+        for line in text.strip().split("\n"):
+            if line:
+                self.assertTrue(line.startswith("｜"), f"unexpected line: {line!r}")
+
+    def test_hr_emitted(self) -> None:
+        text, _ = render_to_line("前\n\n---\n\n後")
+        self.assertIn("────", text)
+
+    def test_no_excessive_blank_lines(self) -> None:
+        md = "段落1\n\n\n\n\n段落2"
+        text, _ = render_to_line(md)
+        self.assertNotIn("\n\n\n", text)
+
+    def test_strong_with_japanese_punctuation_inside(self) -> None:
+        # CommonMark flanking rule rejects `」**` followed by CJK letter; ensure
+        # our residual-emphasis sweep cleans it up regardless.
+        text, _ = render_to_line("**「テスト」**です")
+        self.assertEqual(text, "「テスト」です")
+
+    def test_strong_with_punctuation_boundary_variants(self) -> None:
+        cases = [
+            ("**「テスト」**", "「テスト」"),
+            ("**これは「テスト」**", "これは「テスト」"),
+            ("**テスト「重要」**", "テスト「重要」"),
+            ("**1. テスト**", "1. テスト"),
+            ("「**強調**」", "「強調」"),
+            ("日本語**bold**日本語", "日本語bold日本語"),
+            ("文末を**強調**。", "文末を強調。"),
+        ]
+        for src, expected in cases:
+            with self.subTest(src=src):
+                text, _ = render_to_line(src)
+                self.assertEqual(text, expected)
+
+    def test_em_with_punctuation_boundary(self) -> None:
+        text, _ = render_to_line("これは*斜体*です")
+        self.assertEqual(text, "これは斜体です")
+
+    def test_residual_sweep_does_not_touch_code_block(self) -> None:
+        md = "```\nuse **literal** in code\n```"
+        text, _ = render_to_line(md)
+        self.assertIn("**literal**", text)
+
+    def test_residual_sweep_does_not_touch_inline_code(self) -> None:
+        text, _ = render_to_line("使い方: `**raw**` のように書く")
+        self.assertIn("〈**raw**〉", text)
+
+    def test_unpaired_asterisks_left_alone(self) -> None:
+        text, _ = render_to_line("計算: 2 ** 3 = 8")
+        self.assertIn("**", text)
+
+    def test_complex_mixed_document(self) -> None:
+        md = (
+            "# まとめ\n\n"
+            "**結論**: AはBより速い。\n\n"
+            "## 根拠\n\n"
+            "- 計測した結果が [ベンチマーク](https://bench.example) に記載\n"
+            "- 公式 `documentation` でも触れられている\n\n"
+            "> なお例外あり。\n"
+        )
+        text, urls = render_to_line(md)
+        self.assertIn("■ まとめ", text)
+        self.assertIn("■ 根拠", text)
+        self.assertIn("結論: AはBより速い。", text)
+        self.assertIn("・計測した結果が ベンチマーク に記載", text)
+        self.assertIn("〈documentation〉", text)
+        self.assertTrue(any("｜" in line for line in text.split("\n")))
+        self.assertEqual(urls, ["https://bench.example"])
+
+
+class TestMergeCitations(unittest.TestCase):
+    def test_dedup_preserves_first_occurrence_order(self) -> None:
+        merged = merge_citations(
+            ["https://a", "https://b"], ["https://b", "https://c", "https://a"]
+        )
+        self.assertEqual(merged, ["https://a", "https://b", "https://c"])
+
+    def test_skips_empty(self) -> None:
+        merged = merge_citations(["", "https://a"], ["", None])  # type: ignore[list-item]
+        self.assertEqual(merged, ["https://a"])
+
+    def test_empty_input(self) -> None:
+        self.assertEqual(merge_citations(), [])
+        self.assertEqual(merge_citations([], []), [])
+
+
+class TestFormatWithCitations(unittest.TestCase):
+    def test_no_citations_unchanged(self) -> None:
+        self.assertEqual(format_with_citations("body", []), "body")
+
+    def test_citations_appended_with_header(self) -> None:
+        out = format_with_citations("body", ["https://a", "https://b"])
+        self.assertEqual(out, "body\n\n🔗 参考\n(1) https://a\n(2) https://b")
+
+    def test_caps_at_max(self) -> None:
+        urls = [f"https://x{i}" for i in range(10)]
+        out = format_with_citations("body", urls, max_citations=3)
+        self.assertIn("(1) https://x0", out)
+        self.assertIn("(3) https://x2", out)
+        self.assertNotIn("(4)", out)
+        self.assertNotIn("https://x3", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "boto3>=1.28.0",
     "pytz>=2023.3",
     "xai-sdk>=1.0.0",
+    "markdown-it-py>=3.0.0",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -316,6 +316,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "boto3" },
     { name = "line-bot-sdk" },
+    { name = "markdown-it-py" },
     { name = "openai" },
     { name = "pytz" },
     { name = "xai-sdk" },
@@ -334,6 +335,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.28.0" },
     { name = "line-bot-sdk", specifier = ">=3.17.1" },
+    { name = "markdown-it-py", specifier = ">=3.0.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pytz", specifier = ">=2023.3" },
     { name = "xai-sdk", specifier = ">=1.0.0" },
@@ -712,6 +714,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/41/c7/e8b07aa532669e56baab8404b213b1902678d78d7339e36dc1ecc3a91b32/line_bot_sdk-3.22.0.tar.gz", hash = "sha256:f686586a5e576449b3f8612d761fc79f726b52d817e60f60b69aac1d59e9f25d", size = 468902, upload-time = "2026-01-21T11:24:14.06Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/9c/b03ee25728f76a1292110ed9a7b330bf0c744f0f5fc3ea9ab7db3e3fc01d/line_bot_sdk-3.22.0-py2.py3-none-any.whl", hash = "sha256:64e202330997e02fd7cfe77b51f9df812aff61dd9d0e7ba840e8ecd96c2dda67", size = 818871, upload-time = "2026-01-21T11:24:12.117Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- markdown処理を共通モジュール `lambda/markdown_to_line.py` に切り出し、Grok/Groq/SambaNova 全ての応答で装飾を機械的に除去
- Grokの `response.citations` を本文末尾に番号付きで inline 付加（メッセージ分割はしない）
- 1on1チャットで LINE Loading Animation API を呼び、待ち時間の体感を改善
- 履歴保存は citation footer を含めない `grokBody` を使い、後続のLLMコンテキストがURLで汚染されるのを防止
- CommonMark の left/right-flanking が日本語の `」` 直後の `**` を閉じトークンとして認めない既知問題を、AST後の inline text token に限定した正規表現で補正

## 設計判断（過去の検討で却下したもの）
- プロンプトによるmarkdown禁止強制 → 機械的処理（パーサ）を採用
- メッセージ分割（本文／citations）→ 1バブルにまとめる方が読みやすい
- streaming → 結局1バブルなので利得ゼロ
- Flex Message → 工数大、今回は対象外

## Test plan
- [x] \`uv run pytest\` で44件パス（env vars設定時）
- [x] 新規 \`lambda/tests/test_markdown_to_line.py\` 30件パス（env不要）
- [x] \`uv run ruff check lambda/\` 通過
- [x] \`uv run mypy lambda/...\` 通過
- [x] CDK \`pnpm test\` 通過（snapshot更新含む）
- [x] 約物境界の負ケース、code block内の \`**\` 保護を確認
- [ ] mainマージ後、AWS自動デプロイの Lambda 更新を Actions で確認
- [ ] 実機で 1on1 / グループの両方で動作確認（Grok ツール起動時の loading animation、Groq応答の装飾除去）

🤖 Generated with [Claude Code](https://claude.com/claude-code)